### PR TITLE
Fix nix build for Tidal 2.0 (include hosc 0.20). Update nixpkgs input.

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,29 @@
 {
   "nodes": {
+    "hosc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669944828,
+        "narHash": "sha256-cHEf0yEiwNnEpDj7SSQWRMUEAT5USHuuUCPuzOXHWrk=",
+        "owner": "rd--",
+        "repo": "hosc",
+        "rev": "e77aa67cd0b99a32498fef246a687ba443c9b4be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "rd--",
+        "repo": "hosc",
+        "rev": "e77aa67cd0b99a32498fef246a687ba443c9b4be",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667629849,
-        "narHash": "sha256-P+v+nDOFWicM4wziFK9S/ajF2lc0N2Rg9p6Y35uMoZI=",
+        "lastModified": 1687807295,
+        "narHash": "sha256-7TUD0p0m4mZpIi1O+Cyk5NCqpJUnhv/CJOAuHOndjao=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3bacde6273b09a21a8ccfba15586fb165078fb62",
+        "rev": "6b3d1b1cf13f407fef5e634b224d575eb7211975",
         "type": "github"
       },
       "original": {
@@ -18,17 +35,36 @@
     },
     "root": {
       "inputs": {
+        "hosc": "hosc",
         "nixpkgs": "nixpkgs",
         "utils": "utils"
       }
     },
-    "utils": {
+    "systems": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1687709756,
+        "narHash": "sha256-Y5wKlQSkgEK2weWdOu4J3riRd+kV/VCgHsqLNTTWQ/0=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "rev": "dbabf0ca0c0c4bce6ea5eaf65af5cb694d2082c7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,14 @@
   inputs = {
     utils.url = "github:numtide/flake-utils";
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    # Temporarily add `hosc` at the latest v0.20 commit
+    # (nixpkgs currently only has 0.19.1).
+    # See this comment for details:
+    # https://github.com/tidalcycles/Tidal/pull/1022#issuecomment-1610978403
+    hosc = {
+      url = "github:rd--/hosc?rev=e77aa67cd0b99a32498fef246a687ba443c9b4be";
+      flake = false;
+    };
   };
 
   outputs = inputs: let
@@ -38,6 +46,7 @@
 
     mkPackages = pkgs: let
       project = pkgs.haskellPackages.extend (pkgs.haskell.lib.compose.packageSourceOverrides {
+        hosc = inputs.hosc; # Remove once `hosc` is at 0.20 in nixpkgs.
         tidal = ./.;
         tidal-link = ./tidal-link;
         tidal-listener = ./tidal-listener;


### PR DESCRIPTION
This resolves the nix build issue encountered at
https://github.com/tidalcycles/Tidal/pull/1022, mentioned in https://github.com/tidalcycles/Tidal/pull/1022#issuecomment-1608125266.

Namely, as Tidal 2.0 requires `hosc` `0.20` but nixpkgs currently only provides `0.19.1`, we temporarily include `hosc` `0.20` directly from its source.

This commit also updates the nixpkgs pin to the latest version while we're at it.